### PR TITLE
Remove KLayout 0.26.12 tests for macOS from GitHub CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,10 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest]
         klayout_version: [0.26.12, 1.latest]
+        exclude:
+          - os: macos-latest
+            klayout_version: 0.26.12
+
     steps:
       - uses: actions/checkout@v2
       - name: macOS setup


### PR DESCRIPTION
Test that CI passes